### PR TITLE
Fix slow queries related to dashboard home

### DIFF
--- a/db/migrate/20250624124359_add_index_on_notifications_on_status_created_at_broadcast_id.rb
+++ b/db/migrate/20250624124359_add_index_on_notifications_on_status_created_at_broadcast_id.rb
@@ -1,0 +1,7 @@
+class AddIndexOnNotificationsOnStatusCreatedAtBroadcastId < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index(:notifications, [ :status, :created_at, :broadcast_id ], algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_17_075644) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_24_124359) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -237,6 +237,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_17_075644) do
     t.index ["broadcast_id"], name: "index_notifications_on_broadcast_id"
     t.index ["completed_at"], name: "index_notifications_on_completed_at"
     t.index ["priority"], name: "index_notifications_on_priority"
+    t.index ["status", "created_at", "broadcast_id"], name: "index_notifications_on_status_and_created_at_and_broadcast_id"
     t.index ["status"], name: "index_notifications_on_status"
   end
 


### PR DESCRIPTION
### **Query Summary**

You are running this query:

```sql
SELECT COUNT(*) AS "count_all",
       DATE_TRUNC('month', notifications.created_at) AS "month"
FROM notifications
INNER JOIN broadcasts ON notifications.broadcast_id = broadcasts.id
WHERE broadcasts.account_id = $1
  AND notifications.status = $2
  AND notifications.created_at >= NOW()
GROUP BY DATE_TRUNC('month', notifications.created_at);
```

---

### **Why It’s Slow**

From the plan:

```text
->  Parallel Seq Scan on notifications
      Filter: (((status)::text = $2) AND (created_at >= now()))
```

* The planner is using a **sequential scan** across all rows of `notifications` (possibly millions).
* Even though you **filter by `status` and `created_at`**, it cannot use an index efficiently due to missing compound indexes.
* The join to `broadcasts` is via `broadcast_id`, which is fine, but the bottleneck is filtering `notifications`.

---

### ✅ **Recommended Optimizations**

#### 1. **Create a composite index on `notifications(status, created_at)`**

```sql
CREATE INDEX CONCURRENTLY idx_notifications_status_created_at
ON notifications(status, created_at);
```

This will allow the planner to quickly filter down to relevant `notifications` instead of scanning the whole table.

#### 2. **(Even Better) Create a multicolumn index that includes `broadcast_id`**

Since you're joining on `broadcast_id`, you can go further:

```sql
CREATE INDEX CONCURRENTLY idx_notifications_status_created_at_broadcast_id
ON notifications(status, created_at, broadcast_id);
```

This index helps:

* Filter on `status` and `created_at`
* Lookup `broadcast_id` for the join

> ⚠️ Use `CONCURRENTLY` if you're creating this in production to avoid locking writes.

---

### 🧪 Optional: Materialize Monthly Aggregates

If this query is run frequently (e.g., for dashboards), consider:

* Materialized views
* Cached rollups (e.g., nightly job that precomputes counts per month per account)

---

### ✅ Post-index, re-check the query plan

After adding the index, run:

```sql
EXPLAIN ANALYZE
SELECT COUNT(*) ...
```

You should see the planner **switch to an index scan or bitmap index scan** on `notifications`.

---